### PR TITLE
API: timestampStart rename + MySQL Exception error loop fix

### DIFF
--- a/api/src/main/java/ua/ies/group3/netcafe/api/model/MachineUsage.java
+++ b/api/src/main/java/ua/ies/group3/netcafe/api/model/MachineUsage.java
@@ -19,7 +19,7 @@ public class MachineUsage {
     private long userId;
 
     @Schema(description = "Timestamp")
-    private long timestampStart;
+    private long timestamp;
 
     @Schema(description = "CPU usage")
     private double cpuUsage;
@@ -54,13 +54,13 @@ public class MachineUsage {
     @Schema(description = "GPU temperature")
     private double gpuTemp;
 
-    public MachineUsage(long machineId, long userId, long timestampStart, double cpuUsage,
+    public MachineUsage(long machineId, long userId, long timestamp, double cpuUsage,
                         double gpuUsage, double networkUpUsage, double networkDownUsage, double powerUsage,
                         double diskUsage, double ramUsage, int uptime, List<Integer> softwareUsage,
                         double cpuTemp, double gpuTemp) {
         this.machineId = machineId;
         this.userId = userId;
-        this.timestampStart = timestampStart;
+        this.timestamp = timestamp;
         this.cpuUsage = cpuUsage;
         this.gpuUsage = gpuUsage;
         this.networkUpUsage = networkUpUsage;
@@ -98,12 +98,12 @@ public class MachineUsage {
         this.userId = userId;
     }
 
-    public long getTimestampStart() {
-        return timestampStart;
+    public long getTimestamp() {
+        return timestamp;
     }
 
-    public void setTimestampStart(long timestampStart) {
-        this.timestampStart = timestampStart;
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
     }
 
     public double getCpuUsage() {
@@ -200,7 +200,7 @@ public class MachineUsage {
                 "id='" + id + '\'' +
                 ", machineId=" + machineId +
                 ", userId=" + userId +
-                ", timestampStart=" + timestampStart +
+                ", timestamp=" + timestamp +
                 ", cpuUsage=" + cpuUsage +
                 ", gpuUsage=" + gpuUsage +
                 ", networkUpUsage=" + networkUpUsage +

--- a/api/src/main/java/ua/ies/group3/netcafe/api/rabbitmq/Receiver.java
+++ b/api/src/main/java/ua/ies/group3/netcafe/api/rabbitmq/Receiver.java
@@ -7,6 +7,7 @@ import java.util.concurrent.CountDownLatch;
 import com.google.gson.Gson;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 import ua.ies.group3.netcafe.api.enums.AlarmTypes;
 import ua.ies.group3.netcafe.api.model.Alarm;
@@ -42,7 +43,10 @@ public class Receiver {
         System.out.println("Received Machine Usage\n" + machineUsage);
         machineUsageService.saveMachineUsage(machineUsage); // MongoDB MachineUsage
         sessionService.updateSession(machineUsage);         // MongoDB Session
-        System.out.println("Saving machine MySQL\n" + machineService.updateMachine(machineUsage)); // MySQL Machine
+        try {
+            System.out.println("MySQL saving machine\n" + machineService.updateMachine(machineUsage)); // MySQL Machine
+        } catch (DataIntegrityViolationException ignored) {
+        }
         createAlarmIfNeeded(machineUsage);
         latch.countDown();
     }
@@ -86,7 +90,7 @@ public class Receiver {
                     usage.getUserId(),
                     message.toString(),
                     type.toString(),
-                    usage.getTimestampStart()
+                    usage.getTimestamp()
             ));
         }
         return null;

--- a/api/src/main/java/ua/ies/group3/netcafe/api/repository/MachineRepository.java
+++ b/api/src/main/java/ua/ies/group3/netcafe/api/repository/MachineRepository.java
@@ -16,7 +16,7 @@ public interface MachineRepository extends JpaRepository<Machine, Long> {
 
     @Modifying
     @Query("update Machine m " +
-            "set m.timestamp = :timestampStart," +
+            "set m.timestamp = :timestamp," +
             "m.cpuUsage = :cpuUsage," +
             "m.gpuUsage = :gpuUsage," +
             "m.diskUsage = :diskUsage," +
@@ -28,7 +28,7 @@ public interface MachineRepository extends JpaRepository<Machine, Long> {
             "where m.id = :machineId")
     void updateMachine(
             @Param("machineId") long machineId,
-            @Param("timestampStart") long timestampStart,
+            @Param("timestamp") long timestamp,
             @Param("cpuUsage") double cpuUsage,
             @Param("gpuUsage") double gpuUsage,
             @Param("diskUsage") double diskUsage,

--- a/api/src/main/java/ua/ies/group3/netcafe/api/repository/MachineUsageRepository.java
+++ b/api/src/main/java/ua/ies/group3/netcafe/api/repository/MachineUsageRepository.java
@@ -6,9 +6,9 @@ import ua.ies.group3.netcafe.api.model.MachineUsage;
 import java.util.List;
 
 public interface MachineUsageRepository extends MongoRepository<MachineUsage, String> {
-    List<MachineUsage> findMachineUsageByTimestampStartBetweenOrderByTimestampStart(long timestampStart, long timestampEnd);
+    List<MachineUsage> findMachineUsageByTimestampBetweenOrderByTimestamp(long timestampStart, long timestampEnd);
 
-    List<MachineUsage> findMachineUsageByMachineIdAndTimestampStartBetweenOrderByTimestampStart(long machineId, long timestampStart, long timestampEnd);
+    List<MachineUsage> findMachineUsageByMachineIdAndTimestampBetweenOrderByTimestamp(long machineId, long timestampStart, long timestampEnd);
 
     long count();
 }

--- a/api/src/main/java/ua/ies/group3/netcafe/api/repository/SessionRepositoryImpl.java
+++ b/api/src/main/java/ua/ies/group3/netcafe/api/repository/SessionRepositoryImpl.java
@@ -35,7 +35,7 @@ public class SessionRepositoryImpl implements SessionRepositoryCustom {
             Session newSession = new Session(
                     machineUsage.getMachineId(),
                     machineUsage.getUserId(),
-                    machineUsage.getTimestampStart(),
+                    machineUsage.getTimestamp(),
                     null,
                     1,
                     machineUsage.getCpuUsage(),
@@ -57,7 +57,7 @@ public class SessionRepositoryImpl implements SessionRepositoryCustom {
             // Machine turned off, previous session over.
             if (machineUsage.getUserId() == 0) {
                 System.out.println("Machine usage represents machine turned off (user ID: 0)");
-                update.set("timestampEnd", machineUsage.getTimestampStart());
+                update.set("timestampEnd", machineUsage.getTimestamp());
             // User still using it
             } else {
                 System.out.println("Updating session with new machine usage information.");

--- a/api/src/main/java/ua/ies/group3/netcafe/api/service/MachineService.java
+++ b/api/src/main/java/ua/ies/group3/netcafe/api/service/MachineService.java
@@ -56,7 +56,7 @@ public class MachineService {
                         softwareOptional.ifPresent(softwares::add);
                     }
                 machine.setSoftwares(softwares);
-                machine.setTimestamp(usage.getTimestampStart());
+                machine.setTimestamp(usage.getTimestamp());
                 machine.setCpuUsage(usage.getCpuUsage());
                 machine.setGpuUsage(usage.getGpuUsage());
                 machine.setDiskUsage(usage.getDiskUsage());
@@ -72,7 +72,7 @@ public class MachineService {
             }
             machine.setCurrentUser(null);
             machine.setSoftwares(new ArrayList<>());
-            machine.setTimestamp(usage.getTimestampStart());
+            machine.setTimestamp(usage.getTimestamp());
             machine.setCpuUsage(0);
             machine.setGpuUsage(0);
             machine.setDiskUsage(0);

--- a/api/src/main/java/ua/ies/group3/netcafe/api/service/MachineUsageService.java
+++ b/api/src/main/java/ua/ies/group3/netcafe/api/service/MachineUsageService.java
@@ -15,12 +15,12 @@ public class MachineUsageService {
     @Autowired
     private MachineUsageRepository machineUsageRepository;
 
-    public List<MachineUsage> findMachineUsageByTimestampStartBetween(long timestampStart, long timestampEnd) {
-        return machineUsageRepository.findMachineUsageByTimestampStartBetweenOrderByTimestampStart(timestampStart, timestampEnd);
+    public List<MachineUsage> findMachineUsageByTimestampBetween(long timestampStart, long timestampEnd) {
+        return machineUsageRepository.findMachineUsageByTimestampBetweenOrderByTimestamp(timestampStart, timestampEnd);
     }
 
-    public List<MachineUsage> findMachineUsageByMachineIdAndTimestampStartBetween(long machineId, long timestampStart, long timestampEnd) {
-        return machineUsageRepository.findMachineUsageByMachineIdAndTimestampStartBetweenOrderByTimestampStart(machineId, timestampStart, timestampEnd);
+    public List<MachineUsage> findMachineUsageByMachineIdAndTimestampBetween(long machineId, long timestampStart, long timestampEnd) {
+        return machineUsageRepository.findMachineUsageByMachineIdAndTimestampBetweenOrderByTimestamp(machineId, timestampStart, timestampEnd);
     }
 
     public List<MachineUsage> findAllMachineUsages() {
@@ -30,10 +30,10 @@ public class MachineUsageService {
     public List<MachineUsage> findMachineUsageWithRound(long machineId, long timestampStart, long timestampEnd, int round) {
         List<MachineUsage> usages;
         if (machineId != -1) {
-            usages = findMachineUsageByMachineIdAndTimestampStartBetween(machineId, timestampStart, timestampEnd);
+            usages = findMachineUsageByMachineIdAndTimestampBetween(machineId, timestampStart, timestampEnd);
         }
         else {
-            return findMachineUsageByTimestampStartBetween(timestampStart, timestampEnd);
+            return findMachineUsageByTimestampBetween(timestampStart, timestampEnd);
         }
 
         // Default case, doesn't need to iterate everything
@@ -56,7 +56,7 @@ public class MachineUsageService {
             }
 
             else {
-                usage.setTimestampStart(roundTimestamp(usage, round));
+                usage.setTimestamp(roundTimestamp(usage, round));
                 aggregation.add(usage);
                 aggregation_counter.add(1);
             }
@@ -69,7 +69,7 @@ public class MachineUsageService {
     }
 
     public static long roundTimestamp(MachineUsage usage, int round) {
-        return (usage.getTimestampStart()/round)*round;
+        return (usage.getTimestamp()/round)*round;
     }
 
     public static void updateAverage(MachineUsage lastUsage, MachineUsage usage, Integer counter) {

--- a/datagen/datagen.py
+++ b/datagen/datagen.py
@@ -421,7 +421,7 @@ def main():
                           body=machine.export_data())
             print("sent machine")
             print(users)
-        time.sleep(5)
+        time.sleep(1)
 
     # For testing purposes
     # machineList[0].test_loop()

--- a/datagen/datagen.py
+++ b/datagen/datagen.py
@@ -355,7 +355,7 @@ class Machine():
     def export_data(self):
         obj = {
             'machineId':self.id,
-            'timestampStart':int(time.time()),
+            'timestamp':int(time.time()),
             'cpuUsage':self.usage['cpu'],
             'gpuUsage':self.usage['gpu'],
             'ramUsage':self.usage['ram'],
@@ -421,7 +421,7 @@ def main():
                           body=machine.export_data())
             print("sent machine")
             print(users)
-        time.sleep(1)
+        time.sleep(5)
 
     # For testing purposes
     # machineList[0].test_loop()


### PR DESCRIPTION
## Changes IES_NetCafe: 

- Description of changes

Renamed MachineUsage's timestampStart field to timestamp.
Fixed exception error loop in MySQL by ignoring the benign exceptions using try-catch with an empty catch block.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated *all* the documentation accordingly.



## Checklist
- [X] Does the code run?
- [ ] Does this break anything?
- [ ] There's no spelling errors?

Closes #63